### PR TITLE
Properly sanitize album, artist, and track names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Options:
           By default files are saved in the current directory.
 
   -S, --skip-albums <ALBUMS>
-          Skip downloading these albums, note that albums need to be delimited by ',' eg: -s 'one,two' or --skip-albums=one,two
+          Skip downloading these albums, note that albums need to be delimited by ',' eg: -S 'one,two' or --skip-albums=one,two
 
   -l, --list-available
           List albums/tracks available for download

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,7 +95,9 @@ impl Default for Config {
 fn validate_format(f: &str) -> Result<String, String> {
     let vars = format_container("", "", "", "");
 
-    strfmt(f, &vars).map_err(|err| err.to_string())
+    strfmt(f, &vars).map_err(|err| err.to_string())?;
+
+    Ok(f.to_string())
 }
 
 pub fn expand_tilde(p: &str) -> PathBuf {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,7 +44,7 @@ note that `.mp3` is appended automatically.")]
     pub(crate) track_format: Option<String>,
 
     /// Skip downloading these albums, note that albums need to be delimited by ','
-    /// eg: -s 'one,two' or --skip-albums=one,two
+    /// eg: -S 'one,two' or --skip-albums=one,two
     #[clap(short = 'S', long, value_name = "ALBUMS", value_delimiter = ',')]
     pub(crate) skip_albums: Option<Vec<String>>,
 

--- a/src/lib/spider.rs
+++ b/src/lib/spider.rs
@@ -86,7 +86,7 @@ fn scrape_by_application_ld_json(dom: &Html) -> Option<Album> {
 
         vec![Track {
             num: 1,
-            name: track_name.to_string().replace("/", ":"),
+            name: track_name.to_string(),
             url,
             lyrics: None,
             album: album.clone(),
@@ -113,9 +113,7 @@ fn scrape_by_application_ld_json(dom: &Html) -> Option<Album> {
 
                 Some(Track {
                     num: track.get("position").i32(),
-                    name: decode_html_entities(&track.get("item.name").to_string())
-                        .replace("/", ":")
-                        .into(),
+                    name: decode_html_entities(&track.get("item.name").to_string()).into(),
                     url: decode_html_entities(&url).to_string(),
                     lyrics: Some(track.get("item.recordingOf.lyrics.text").to_string()),
                     album: album.clone(),


### PR DESCRIPTION
Sanitize album, artist, and track names for valid file paths without changing id3 tags
fix #6 and derivatives.
Fixed #7 with the last commit 8fb94ec